### PR TITLE
Add Concurrent sampling to bootstrap

### DIFF
--- a/rbm_sample.py
+++ b/rbm_sample.py
@@ -297,7 +297,9 @@ logz, logz_up, logz_down = rbm.annealed_importance_sampling(k=1, betas = 10000, 
 print("LogZ ", logz, logz_up, logz_down)
 
 # Save data - in img directory
-np.savetxt(parameters['image_dir'] + "Mag_history", magv)
+#since mag history will be N_gibbssample * N_concurrent * 2 we should output mag history for each concurrent sample
+for i in range(len(magv[0, :, 0]))
+    np.savetxt(parameters['image_dir'] + "Mag_history_sample_" + str(i), magv[:, i, :])
 
 
 

--- a/rbm_sample.py
+++ b/rbm_sample.py
@@ -102,9 +102,9 @@ def ising_averages(mag_history, model_size, label=""):
     susc_avg = susc_resample.mean(axis=0)
     susc_std = susc_resample.std(axis=0)
 
-    #finally take average across concurrent samples, can also compare to adding std in quadrature
+    #finally take average across concurrent samples, can also compare to adding std error in quad and divide by N_conc to account for taking mean
 
-    print(label, " ::: Magnetization: ", mag_avg.mean(), " +- ", mag_avg.std()/sqrt(len(mag_avg)), "compare to std error added in quad +- ", sqrt(sum(mag_std**2/resample_size)), " - Susceptibility:", susc_avg.mean() , " +- ", susc_avg.std()/sqrt(len(mag_avg)), "compare to std error added in quad +- ", sqrt(sum(susc_std**2/resample_size)))
+    print(label, " ::: Magnetization: ", mag_avg.mean(), " +- ", mag_avg.std()/sqrt(len(mag_avg)), "compare to std error added in quad +- ", sqrt(sum(mag_std**2/(resample_size*len(mag_avg)))), " - Susceptibility:", susc_avg.mean() , " +- ", susc_avg.std()/sqrt(len(mag_avg)), "compare to std error added in quad +- ", sqrt(sum(susc_std**2/(resample_size*len(mag_avg)))))
     #plt.plot(mag_history[:,0], linewidth=0.2)
     #plt.show()
 

--- a/rbm_sample.py
+++ b/rbm_sample.py
@@ -101,7 +101,7 @@ def ising_averages(mag_history, model_size, label=""):
     susc_resample = bootstrap_resample(mag_err, n=resample_size)
     #take average across resampled states and std dev.
     susc_avg = susc_resample.mean(axis=0)
-    susc_std = sesc_resample.std(axis=0)
+    susc_std = susc_resample.std(axis=0)
 
     #finally take average across concurrent samples, can also compare to adding std in quadrature
 

--- a/rbm_sample.py
+++ b/rbm_sample.py
@@ -95,8 +95,7 @@ def ising_averages(mag_history, model_size, label=""):
     mag_avg = mag_resample.mean(axis=0)
     mag_std = mag_resample.std(axis=0)
 
-    #now take mag_history[:, 0, :] (all states, m ,for all conc samples) and find susc, then
-    #input the susc to bootstrap to return n_resample * n_conc array of susceptibility
+    #now take mag_history[:, 0, :] (all states, m ,for all conc samples) and find susc, then input the susc to bootstrap to return n_resample * n_conc array of susceptibility
     mag_err = model_size*((mag_history[:, 0, :]-mag_history[:, 0, :].mean(axis=0))**2)
     susc_resample = bootstrap_resample(mag_err, n=resample_size)
     #take average across resampled states and std dev.

--- a/rbm_sample.py
+++ b/rbm_sample.py
@@ -190,9 +190,10 @@ def sample_from_rbm(steps, model, image_size, nstates=30, v_in=None):
             if parameters['output_states']:
                 imgshow(parameters['image_dir'] + "dream" + str(s),
                         make_grid(v.view(-1, 1, image_size, image_size)))
-            else:
-                imgshow(parameters['image_dir'] + "dream" + str(s),
-                        make_grid(v_prob.view(-1, 1, image_size, image_size)))
+        #don't think states should be outputted at all if output_states is false
+        #    else:
+        #        imgshow(parameters['image_dir'] + "dream" + str(s),
+        #                make_grid(v_prob.view(-1, 1, image_size, image_size)))
             if args.verbose:
                 print(s, "OK")
 

--- a/rbm_sample.py
+++ b/rbm_sample.py
@@ -89,15 +89,15 @@ def ising_averages(mag_history, model_size, label=""):
     # Bootstrap samples
     resample_size = 50000
     #get resample states
-    mag_resample = bootstrap_resample(mag_history[:,0], n=resample_size)
+    mag_resample = bootstrap_resample(mag_history[:, 0, :], n=resample_size)
     
     #Now take average across resampled states and std dev.
     mag_avg = mag_resample.mean(axis=0)
     mag_std = mag_resample.std(axis=0)
 
-    #now take mag_history[:, :, 0] (all states, for all conc samples, m) and find susc, then
+    #now take mag_history[:, 0, :] (all states, m ,for all conc samples) and find susc, then
     #input the susc to bootstrap to return n_resample * n_conc array of susceptibility
-    mag_err = model_size*((mag_history[:, :, 0]-mag_history[:, :, 0].mean(axis=0))**2)
+    mag_err = model_size*((mag_history[:, 0, :]-mag_history[:, 0, :].mean(axis=0))**2)
     susc_resample = bootstrap_resample(mag_err, n=resample_size)
     #take average across resampled states and std dev.
     susc_avg = susc_resample.mean(axis=0)
@@ -298,8 +298,8 @@ print("LogZ ", logz, logz_up, logz_down)
 
 # Save data - in img directory
 #since mag history will be N_gibbssample * N_concurrent * 2 we should output mag history for each concurrent sample
-for i in range(len(magv[0, :, 0])):
-    np.savetxt(parameters['image_dir'] + "Mag_history_sample_" + str(i), magv[:, i, :])
+for i in range(len(magv[0, 0, :])):
+    np.savetxt(parameters['image_dir'] + "Mag_history_sample_" + str(i), magv[:, :, i])
 
 
 

--- a/rbm_sample.py
+++ b/rbm_sample.py
@@ -126,7 +126,8 @@ def sample_probability(prob, random):
         :return: binary sample of probabilities
     """
     torchReLu = nn.ReLU()
-    return torchReLu(torch.sign(prob - random)).data
+    #Didn't work for Tomasso and I without adding in Variable()
+    return torchReLu(Variable(torch.sign(prob - random))).data
 
 
 def hidden_from_visible(visible, W, h_bias):

--- a/rbm_sample.py
+++ b/rbm_sample.py
@@ -81,24 +81,31 @@ def get_ising_variables(field, sign=-1):
 
 
 def ising_magnetization(field):
-    m = np.abs((field).mean())
+    #axis=1 to return the average field for each state dimension N_concsamp x 1 
+    m = np.abs((field).mean(axis=1))
     return np.array([m, m * m])
 
 def ising_averages(mag_history, model_size, label=""):
     # Bootstrap samples
     resample_size = 50000
+    #get resample states
     mag_resample = bootstrap_resample(mag_history[:,0], n=resample_size)
-    #print('original mean:', mag_history[:,0].mean() )
-    #print('resampled mean:', mag_resample.mean() )
-    #print('resampled error:', mag_resample.std()/sqrt(resample_size) )
+    
+    #Now take average across resampled states and std dev.
+    mag_avg = mag_resample.mean(axis=0)
+    mag_std = mag_resample.std(axis=0)
 
-    mag_err = model_size*((mag_history[:,0]-mag_history[:,0].mean())**2)
+    #now take mag_history[:, :, 0] (all states, for all conc samples, m) and find susc, then
+    #input the susc to bootstrap to return n_resample * n_conc array of susceptibility
+    mag_err = model_size*((mag_history[:, :, 0]-mag_history[:, :, 0].mean(axis=0))**2)
     susc_resample = bootstrap_resample(mag_err, n=resample_size)
-    #print('original susc mean:', mag_err.mean() )
-    #print('resampled susc mean:', susc_resample.mean() )
-    #print('resampled susc error:', susc_resample.std()/sqrt(resample_size) )
+    #take average across resampled states and std dev.
+    susc_avg = susc_resample.mean(axis=0)
+    susc_std = sesc_resample.std(axis=0)
 
-    print(label, " ::: Magnetization: ", mag_resample.mean(), " +- ", mag_resample.std()/sqrt(resample_size), " - Susceptibility:", susc_resample.mean() , " +- ", susc_resample.std()/sqrt(resample_size))
+    #finally take average across concurrent samples, can also compare to adding std in quadrature
+
+    print(label, " ::: Magnetization: ", mag_avg.mean(), " +- ", mag_avg.std()/sqrt(len(mag_avg)), "compare to std error added in quad +- ", sqrt(sum(mag_std**2/resample_size)), " - Susceptibility:", susc_avg.mean() , " +- ", susc_avg.std()/sqrt(len(mag_avg)), "compare to std error added in quad +- ", sqrt(sum(susc_std**2/resample_size)))
     #plt.plot(mag_history[:,0], linewidth=0.2)
     #plt.show()
 

--- a/rbm_sample.py
+++ b/rbm_sample.py
@@ -294,8 +294,8 @@ ising_averages(magh, model_size, "h")
 logz, logz_up, logz_down = rbm.annealed_importance_sampling(k=1, betas = 10000, num_chains = 200)
 print("LogZ ", logz, logz_up, logz_down)
 
-# Save data
-np.savetxt("Mag_history", magv)
+# Save data - in img directory
+np.savetxt(parameters['image_dir'] + "Mag_history", magv)
 
 
 

--- a/rbm_sample.py
+++ b/rbm_sample.py
@@ -298,7 +298,7 @@ print("LogZ ", logz, logz_up, logz_down)
 
 # Save data - in img directory
 #since mag history will be N_gibbssample * N_concurrent * 2 we should output mag history for each concurrent sample
-for i in range(len(magv[0, :, 0]))
+for i in range(len(magv[0, :, 0])):
     np.savetxt(parameters['image_dir'] + "Mag_history_sample_" + str(i), magv[:, i, :])
 
 


### PR DESCRIPTION
Opened up capability to use concurrent sampling along with your preexisting bootstrap sampling

I also added Variable() to sample_probability because without this the code doesn't run on either mine or Tommaso's machines

Tested that this still works with concurrent sample = 1

Changed the printed output to have <Magnetization> +- <concurrent sample error> compare to <propagating errors through taking mean> 

and same for magnetic susceptibility